### PR TITLE
Service fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ git clone https://github.com/orlandorode97/mailx-google-service.git
 
 `mailx-google-services` requires a `.env` at the root of the project with the following variables:
 ```sh
-POSTGRES_HOST=
-POSTGRES_PORT=
 POSTGRES_USER=
 POSTGRES_PASSWORD=
-POSTGRES_DB_NAME=
-POSTGRES_SSL_MODE=
+POSTGRES_HOST=mailx-google-service-db-1
+POSTGRES_HOST_GOOSE=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB_NAME=postgres
+POSTGRES_SSL_MODE=disable
+POSTGRES_DB_SCHEMA=public
+
 
 GOOGLE_REDIRECT_URL=
 GOOGLE_CLIENT_ID=

--- a/auth/endpoint.go
+++ b/auth/endpoint.go
@@ -7,14 +7,22 @@ import (
 )
 
 type Endpoints struct {
+	LogoutEndpoint           endpoint.Endpoint
 	GetOauthUrlEndpoint      endpoint.Endpoint
 	GetOauthCallbackEndpoint endpoint.Endpoint
 }
 
 func MakeEndpoints(s Service) Endpoints {
 	return Endpoints{
+		LogoutEndpoint:           MakeLogoutEndpoint(s),
 		GetOauthUrlEndpoint:      MakeGetOauthUrlEndpoint(s),
 		GetOauthCallbackEndpoint: MakeGetOauthCallbackEndpoint(s),
+	}
+}
+
+func MakeLogoutEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		return logoutResponse{}, nil
 	}
 }
 
@@ -28,6 +36,7 @@ func MakeGetOauthUrlEndpoint(s Service) endpoint.Endpoint {
 		return loginResponse{AuthUrl: url}, nil
 	}
 }
+
 func MakeGetOauthCallbackEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 		req := request.(callbackRequest)
@@ -42,6 +51,9 @@ func MakeGetOauthCallbackEndpoint(s Service) endpoint.Endpoint {
 		return callbackResponse{JWT: jwt}, nil
 	}
 }
+
+type logoutResponse struct{}
+type logoutRequest struct{}
 
 type loginRequest struct{}
 type loginResponse struct {

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -38,6 +38,11 @@ func (m MockMailxService) AddGmailServiceByID(ID string, gmailSvc *gmail.Service
 	m.Called(ID, gmailSvc)
 }
 
+func (m MockMailxService) RecreateGmailService(ctx context.Context, ID string) (*gmail.Service, error) {
+	args := m.Called(ctx, ID)
+	return args.Get(0).(*gmail.Service), args.Error(1)
+}
+
 type MockOAuthConfig struct {
 	mock.Mock
 }

--- a/auth/transport_test.go
+++ b/auth/transport_test.go
@@ -70,7 +70,7 @@ func TestEncodeCallBackRequest(t *testing.T) {
 				JWT: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			},
 			httpStatus:          http.StatusPermanentRedirect,
-			redirectUrlExpected: "http://localhost:3000/success?mailx_google_auth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			redirectUrlExpected: "http://localhost:3000/success?mailx_google_success=true",
 		},
 		{
 			name: "failure - error configuring gmail service",

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -67,7 +67,7 @@ func buildDSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		viper.GetString("POSTGRES_USER"),
 		viper.GetString("POSTGRES_PASSWORD"),
-		viper.GetString("POSTGRES_HOST"),
+		viper.GetString("POSTGRES_HOST_GOOSE"),
 		viper.GetInt("POSTGRES_PORT"),
 		viper.GetString("POSTGRES_DB_NAME"),
 		viper.GetString("POSTGRES_SSL_MODE"),

--- a/cmd/mailx-google-service/main.go
+++ b/cmd/mailx-google-service/main.go
@@ -46,6 +46,15 @@ func main() {
 
 	repo := repopg.New(sqlx.NewDb(db, "postgres"))
 
+	if repo == nil {
+		logger.Log(
+			"message", "it was not possible to open a new connection with the database.",
+			"err", err.Error(),
+			"severity", "CRITICAL",
+		)
+		return
+	}
+
 	oauthConfig := google.NewConfig()
 
 	mailxSvc := mailx.New(logger, oauthConfig)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./data/db:/var/lib/postgresql/data
+      - "dbdata:/var/lib/postgresql/data"
     restart: always
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
@@ -23,6 +23,8 @@ services:
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256"
     ports:
       - 5432:5432
+volumes:
+  dbdata:
 
 
     

--- a/migrations/20220124004601_google_users_table.go
+++ b/migrations/20220124004601_google_users_table.go
@@ -14,12 +14,12 @@ func upGoogleUsersTableGo(tx *sql.Tx) error {
 	// This code is executed when the migration is applied.
 	_, err := tx.Exec(`
 		CREATE TABLE IF NOT EXISTS users(
-			google_id CHAR(50) PRIMARY KEY,
-			name CHAR(50) NOT NULL,
-			given_name CHAR(50) NOT NULL,
-			family_name CHAR(50) NOT NULL,
-			picture CHAR(100) NOT NULL,
-			locale CHAR(10),
+			google_id VARCHAR(50) PRIMARY KEY,
+			name VARCHAR(50) NOT NULL,
+			given_name VARCHAR(50) NOT NULL,
+			family_name VARCHAR(50) NOT NULL,
+			picture VARCHAR(100) NOT NULL,
+			locale VARCHAR(10),
 			created_at TIMESTAMP NOT NULL DEFAULT now(),
 			updated_at TIMESTAMP NOT NULL DEFAULT now()
 		);

--- a/migrations/20220124234200_google_auth_users_table.go
+++ b/migrations/20220124234200_google_auth_users_table.go
@@ -14,11 +14,11 @@ func upGoogleAuthUsersTable(tx *sql.Tx) error {
 	_, err := tx.Exec(`
 		CREATE TABLE IF NOT EXISTS auth_users(
 			id SERIAL PRIMARY KEY,
-			google_id CHAR(50) NOT NULL,
+			google_id VARCHAR(50) NOT NULL,
 			access_token TEXT NOT NULL,
 			token_expiration DATE NOT NULL,
 			refresh_token TEXT NOT NULL,
-			token_type CHAR(10) NOT NULL,
+			token_type VARCHAR(10) NOT NULL,
 			is_active BOOLEAN NOT NULL DEFAULT TRUE,
 			created_at TIMESTAMP NOT NULL DEFAULT now(),
 			updated_at TIMESTAMP NOT NULL DEFAULT now()

--- a/pkg/repos/postgres/postgres.go
+++ b/pkg/repos/postgres/postgres.go
@@ -16,6 +16,10 @@ type repository struct {
 }
 
 func New(db *sqlx.DB) repos.Repository {
+	if err := db.Ping(); err != nil {
+		return nil
+	}
+
 	return &repository{
 		db: db,
 	}

--- a/service.go
+++ b/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-kit/log"
+	"github.com/orlandorode97/mailx-google-service/pkg/repos"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
@@ -22,24 +23,28 @@ const (
 type Service interface {
 	// GetGmailService returns a gmail pointer service by the email of the user.
 	GetGmailService(string) *gmail.Service
-	// ConfigGmailService returns a new gmail service instance.
+	// CreateGmailService returns a new gmail service instance.
 	CreateGmailService(*oauth2.Token) (*gmail.Service, error)
 	// AddGmailServiceByID creates a new entry of a pointer gmail service by google user ID.
 	AddGmailServiceByID(string, *gmail.Service)
+	// RecreateGmailService returns a new gmail service when a service is not attached to a user
+	RecreateGmailService(context.Context, string) (*gmail.Service, error)
 }
 
 type service struct {
 	logger log.Logger
 	//`config` keeps the oauth2 configuration that holds google_client_id, client_secret, and other needed things.
 	config *oauth2.Config
+	repo   repos.Repository
 	//Map that holds google user ID as a key and stores a pointer gmail service.
 	gmailSvcs map[string]*gmail.Service
 }
 
-func New(logger log.Logger, config *oauth2.Config) Service {
+func New(logger log.Logger, repo repos.Repository, config *oauth2.Config) Service {
 	return &service{
 		logger:    logger,
 		config:    config,
+		repo:      repo,
 		gmailSvcs: make(map[string]*gmail.Service),
 	}
 }
@@ -68,4 +73,23 @@ func (s *service) CreateGmailService(token *oauth2.Token) (*gmail.Service, error
 		return nil, err
 	}
 	return gmailSvc, err
+}
+
+func (s *service) RecreateGmailService(ctx context.Context, ID string) (*gmail.Service, error) {
+	token, err := s.repo.GetTokenByUserId(ctx, ID)
+	if err != nil {
+		return nil, err
+	}
+
+	svc, err := s.CreateGmailService(&oauth2.Token{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		TokenType:    token.TokenType,
+		Expiry:       token.TokenExpiration,
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.AddGmailServiceByID(ID, svc)
+	return svc, nil
 }


### PR DESCRIPTION
### Summary
- Create in global service `RecreateGmailService` to generate a Gmail service in case a user does not have attached a service.
- Pass user ID through HTTP request context.