### PR TITLE
Gmail service refactor

### DIFF
--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -17,31 +17,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/oauth2"
-	"google.golang.org/api/gmail/v1"
 )
 
 type MockMailxService struct {
 	mock.Mock
 }
 
-func (m MockMailxService) GetGmailService(userId string, typeSvc int) interface{} {
-	args := m.Called(userId, typeSvc)
-	return args.Get(0)
+func (m MockMailxService) GetGmailService(userID string) google.Service {
+	args := m.Called(userID)
+	return args.Get(0).(google.Service)
 }
 
-func (m MockMailxService) CreateGmailService(token *oauth2.Token) (*gmail.Service, error) {
+func (m MockMailxService) CreateGmailService(token *oauth2.Token) (google.Service, error) {
 	args := m.Called(token)
-	return args.Get(0).(*gmail.Service), args.Error(1)
+	return args.Get(0).(google.Service), args.Error(1)
 }
 
-func (m MockMailxService) AddGmailServiceByID(ID string, gmailSvc *gmail.Service) *gmail.Service {
-	args := m.Called(ID, gmailSvc)
-	return args.Get(0).(*gmail.Service)
+func (m MockMailxService) AddGmailServiceByID(userID string, gmailSvc google.Service) google.Service {
+	args := m.Called(userID, gmailSvc)
+	return args.Get(0).(google.Service)
 }
 
-func (m MockMailxService) RecreateGmailService(ctx context.Context, ID string) (*gmail.Service, error) {
-	args := m.Called(ctx, ID)
-	return args.Get(0).(*gmail.Service), args.Error(1)
+func (m MockMailxService) RecreateGmailService(ctx context.Context, userID string) (google.Service, error) {
+	args := m.Called(ctx, userID)
+	return args.Get(0).(google.Service), args.Error(1)
 }
 
 type MockOAuthConfig struct {
@@ -210,7 +209,7 @@ func TestConfigGmailServiceUser(t *testing.T) {
 		code            string
 		token           *oauth2.Token
 		tokenErr        error
-		gmailSvc        *gmail.Service
+		gmailSvc        google.Service
 		gmailSvcErr     error
 		expectedUser    *models.User
 		expectedUserErr error
@@ -225,7 +224,7 @@ func TestConfigGmailServiceUser(t *testing.T) {
 			token: &oauth2.Token{
 				AccessToken: "random access token",
 			},
-			gmailSvc: &gmail.Service{},
+			gmailSvc: &google.GmailService{},
 			expectedUser: &models.User{
 				ID:   "1",
 				Name: "Orlando",
@@ -239,7 +238,7 @@ func TestConfigGmailServiceUser(t *testing.T) {
 			code:         "12345678",
 			token:        nil,
 			tokenErr:     errors.New("error generating the oauth token access."),
-			gmailSvc:     &gmail.Service{},
+			gmailSvc:     &google.GmailService{},
 			expectedUser: &models.User{},
 			assertErr:    assert.NotNil,
 			assertEqual:  assert.NotEqual,
@@ -251,7 +250,7 @@ func TestConfigGmailServiceUser(t *testing.T) {
 			token: &oauth2.Token{
 				AccessToken: "random access token",
 			},
-			gmailSvc:     &gmail.Service{},
+			gmailSvc:     &google.GmailService{},
 			gmailSvcErr:  errors.New("error gmail service cannot be configured."),
 			expectedUser: &models.User{},
 			assertErr:    assert.NotNil,
@@ -264,7 +263,7 @@ func TestConfigGmailServiceUser(t *testing.T) {
 			token: &oauth2.Token{
 				AccessToken: "random access token",
 			},
-			gmailSvc: &gmail.Service{},
+			gmailSvc: &google.GmailService{},
 			expectedUser: &models.User{
 				ID:   "1",
 				Name: "Orlando",
@@ -280,7 +279,7 @@ func TestConfigGmailServiceUser(t *testing.T) {
 			token: &oauth2.Token{
 				AccessToken: "random access token",
 			},
-			gmailSvc: &gmail.Service{},
+			gmailSvc: &google.GmailService{},
 			expectedUser: &models.User{
 				ID:   "1",
 				Name: "Orlando",

--- a/messages/endpoint.go
+++ b/messages/endpoint.go
@@ -1,0 +1,42 @@
+package messages
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"google.golang.org/api/gmail/v1"
+)
+
+type Endpoints struct {
+	GetMessagesEndpoint endpoint.Endpoint
+}
+
+func MakeEndpoints(s Service) Endpoints {
+	return Endpoints{
+		GetMessagesEndpoint: MakeGetMessages(s),
+	}
+}
+
+func MakeGetMessages(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(getMessagesRequest)
+		messages, err := s.GetMessages(ctx, req.UserID)
+		if err != nil {
+			return getMessagesResponse{
+				Err: err,
+			}, nil
+		}
+		return getMessagesResponse{
+			Messages: messages,
+		}, nil
+	}
+}
+
+type getMessagesRequest struct {
+	UserID string
+}
+
+type getMessagesResponse struct {
+	Messages []*gmail.Message `json:"messages"`
+	Err      error            `json:"error,omitempty"`
+}

--- a/messages/service.go
+++ b/messages/service.go
@@ -1,0 +1,64 @@
+package messages
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/orlandorode97/mailx-google-service"
+	"github.com/orlandorode97/mailx-google-service/pkg/google"
+	"github.com/orlandorode97/mailx-google-service/pkg/repos"
+	"google.golang.org/api/gmail/v1"
+)
+
+type Service interface {
+	GetMessages(context.Context, string) ([]*gmail.Message, error)
+}
+
+type service struct {
+	logger   log.Logger
+	repo     repos.Repository
+	mailxSvc mailx.Service
+}
+
+func New(logger log.Logger, repo repos.Repository, mailx mailx.Service) Service {
+	return &service{
+		logger:   logger,
+		repo:     repo,
+		mailxSvc: mailx,
+	}
+}
+
+func (s *service) getMessageService(userID string) google.Messenger {
+	svc := s.mailxSvc.GetGmailService(userID)
+	if svc == nil {
+		return nil
+	}
+
+	return svc.GetMessagesService()
+}
+
+func (s *service) recreateMessageService(ctx context.Context, userID string) (google.Messenger, error) {
+	_, err := s.mailxSvc.RecreateGmailService(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return s.getMessageService(userID), nil
+}
+
+func (s *service) GetMessages(ctx context.Context, userID string) ([]*gmail.Message, error) {
+	var svc google.Messenger
+	var err error
+	if svc = s.getMessageService(userID); svc == nil {
+		svc, err = s.recreateMessageService(context.Background(), userID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	messages, err := svc.List(userID).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	return messages.Messages, nil
+}

--- a/messages/transport.go
+++ b/messages/transport.go
@@ -1,0 +1,57 @@
+package messages
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/orlandorode97/mailx-google-service/pkg/middlewares"
+	"github.com/orlandorode97/mailx-google-service/pkg/models"
+)
+
+func MakeHandler(messagesService Service, logger log.Logger) http.Handler {
+	r := mux.NewRouter()
+
+	e := MakeEndpoints(messagesService)
+	options := []kithttp.ServerOption{
+		kithttp.ServerErrorEncoder(models.ErrorEncoder),
+	}
+	r.Methods(http.MethodGet).Path("/messages/").Handler(kithttp.NewServer(
+		e.GetMessagesEndpoint,
+		decodeMessageRequest,
+		encodeMessageResponse,
+		options...,
+	))
+
+	return middlewares.Authentication(r)
+}
+
+func decodeMessageRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	if err, ok := r.Context().Value(middlewares.InvalidAuthKey).(error); ok && err != nil {
+		return nil, err
+	}
+
+	userID, ok := r.Context().Value(middlewares.UserIDKey).(string)
+	if !ok {
+		return nil, nil
+	}
+
+	return getMessagesRequest{
+		UserID: userID,
+	}, nil
+}
+
+func encodeMessageResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	if e, ok := response.(errorer); ok && e.error() != nil {
+		return e.error()
+	}
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type errorer interface {
+	error() error
+}

--- a/pkg/google/label.go
+++ b/pkg/google/label.go
@@ -1,18 +1,73 @@
 package google
 
 import (
+	"context"
+
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/googleapi"
 )
 
+type LabelsService struct {
+	s   *gmail.UsersLabelsService
+	ctx context.Context
+}
+
+func NewLabelsService(labelSvc *gmail.UsersLabelsService) *LabelsService {
+	return &LabelsService{
+		ctx: context.Background(),
+		s:   labelSvc,
+	}
+}
+
+func (l *LabelsService) Create(userID string, label *gmail.Label) LabelerClient {
+	createCall := l.s.Create(userID, label)
+	createCall.Context(l.ctx)
+	return createCall
+}
+
+func (l *LabelsService) Delete(userID string, labelID string) LabelerClientDelete {
+	deleteCall := l.s.Delete(userID, labelID)
+	deleteCall.Context(l.ctx)
+	return deleteCall
+}
+
+func (l *LabelsService) Get(userID string, labelID string) LabelerClient {
+	getCall := l.s.Get(userID, labelID)
+	getCall.Context(l.ctx)
+	return getCall
+}
+
+func (l *LabelsService) List(userID string) LabelerClientList {
+	listCall := l.s.List(userID)
+	listCall.Context(l.ctx)
+	return listCall
+}
+
+func (l *LabelsService) Patch(userID string, labelID string, label *gmail.Label) LabelerClient {
+	patchCall := l.s.Patch(userID, labelID, label)
+	patchCall.Context(l.ctx)
+	return patchCall
+}
+
+func (l *LabelsService) Update(userID string, labelID string, label *gmail.Label) LabelerClient {
+	updateCall := l.s.Update(userID, labelID, label)
+	updateCall.Context(l.ctx)
+	return updateCall
+}
+
 /*
- The listed interfaces represents an abstraction of the *gmail.UserLabelsService and its methods and actioners:
-	Create -> Do()
-	Delete -> Do()
-	Get -> Do()
-	Patch -> Do()
-	Update -> Do()
+ The listed interfaces represents an abstraction of the LabelerClient
+	Create -> Do() (*gmail.Label, error)
+	Delete -> Do() error
+	Get -> Do() (*gmail.Label, error)
+	List -> Do() (*gmail.ListLabelsResponse, error)
+	Patch -> Do() (*gmail.Label, error)
+	Update -> Do() (*gmail.Label, error)
 */
+
+type LabelerClientDelete interface {
+	Do(opts ...googleapi.CallOption) error
+}
 
 type LabelerClient interface {
 	Do(opts ...googleapi.CallOption) (*gmail.Label, error)
@@ -27,7 +82,7 @@ type LabelCreatorCall interface {
 }
 
 type LabelDeletorCall interface {
-	Delete(string, string) LabelerClient
+	Delete(string, string) LabelerClientDelete
 }
 
 type LabelGetterCall interface {

--- a/pkg/google/message.go
+++ b/pkg/google/message.go
@@ -1,0 +1,135 @@
+package google
+
+import (
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/googleapi"
+)
+
+type MessagesService struct {
+	s *gmail.UsersMessagesService
+}
+
+func NewMessagesService(messagesSvc *gmail.UsersMessagesService) *MessagesService {
+	return &MessagesService{
+		s: messagesSvc,
+	}
+}
+
+func (m *MessagesService) BatchDelete(userID string, req *gmail.BatchDeleteMessagesRequest) MessengerClient {
+	return m.s.BatchDelete(userID, req)
+}
+func (m *MessagesService) BatchModify(userID string, req *gmail.BatchModifyMessagesRequest) MessengerClient {
+	return m.s.BatchModify(userID, req)
+}
+func (m *MessagesService) Delete(userID string, messageID string) MessengerClient {
+	return m.s.Delete(userID, messageID)
+}
+func (m *MessagesService) Get(userID string, messageID string) MessengerClientResp {
+	return m.s.Get(userID, messageID)
+}
+func (m *MessagesService) Import(userID string, message *gmail.Message) MessengerClientResp {
+	return m.s.Import(userID, message)
+}
+func (m *MessagesService) Insert(userID string, message *gmail.Message) MessengerClientResp {
+	return m.s.Insert(userID, message)
+}
+func (m *MessagesService) List(userID string) MessengerClientList {
+	return m.s.List(userID)
+}
+func (m *MessagesService) Modify(userID string, messageID string, req *gmail.ModifyMessageRequest) MessengerClientResp {
+	return m.s.Modify(userID, messageID, req)
+}
+func (m *MessagesService) Send(userID string, message *gmail.Message) MessengerClientResp {
+	return m.s.Send(userID, message)
+}
+func (m *MessagesService) Trash(userID string, messageID string) MessengerClientResp {
+	return m.s.Trash(userID, messageID)
+}
+func (m *MessagesService) Untrash(userID string, messageID string) MessengerClientResp {
+	return m.s.Untrash(userID, messageID)
+}
+
+/*
+ The listed interfaces represents an abstraction of the *gmail.UsersMessagesService and its methods and actioners:
+	BatchDelete -> Do()
+	BatchModify -> Do()
+	Delete -> Do()
+	Get -> Do()
+	Import -> Do()
+	Insert -> Do()
+	List -> Do()
+	Modify -> Do()
+	Send -> Do()
+	Trash -> Do()
+	Untrash -> Do()
+*/
+
+type MessengerClient interface {
+	Do(opts ...googleapi.CallOption) error
+}
+
+type MessengerClientResp interface {
+	Do(opts ...googleapi.CallOption) (*gmail.Message, error)
+}
+
+type MessengerClientList interface {
+	Do(opts ...googleapi.CallOption) (*gmail.ListMessagesResponse, error)
+}
+
+type MessageBatchDeletorCall interface {
+	BatchDelete(string, *gmail.BatchDeleteMessagesRequest) MessengerClient
+}
+
+type MessageBatchModifierCall interface {
+	BatchModify(string, *gmail.BatchModifyMessagesRequest) MessengerClient
+}
+
+type MessageDeletorCall interface {
+	Delete(string, string) MessengerClient
+}
+
+type MessageGetterCall interface {
+	Get(string, string) MessengerClientResp
+}
+
+type MessageImporterCall interface {
+	Import(string, *gmail.Message) MessengerClientResp
+}
+
+type MessageInserterCall interface {
+	Insert(string, *gmail.Message) MessengerClientResp
+}
+
+type MessageListerCall interface {
+	List(string) MessengerClientList
+}
+
+type MessageModifierCall interface {
+	Modify(string, string, *gmail.ModifyMessageRequest) MessengerClientResp
+}
+
+type MessageSenderCall interface {
+	Send(string, *gmail.Message) MessengerClientResp
+}
+
+type MessageTrasherCall interface {
+	Trash(string, string) MessengerClientResp
+}
+
+type MessageUntrasherCall interface {
+	Untrash(string, string) MessengerClientResp
+}
+
+type Messenger interface {
+	MessageBatchDeletorCall
+	MessageBatchModifierCall
+	MessageDeletorCall
+	MessageGetterCall
+	MessageImporterCall
+	MessageInserterCall
+	MessageListerCall
+	MessageModifierCall
+	MessageSenderCall
+	MessageTrasherCall
+	MessageUntrasherCall
+}

--- a/pkg/google/service.go
+++ b/pkg/google/service.go
@@ -1,0 +1,42 @@
+package google
+
+import "google.golang.org/api/gmail/v1"
+
+type Service interface {
+	GetLabelsService() Labeler
+	GetMessagesService() Messenger
+}
+
+type GmailService struct {
+	Users    *gmail.UsersService
+	Labels   *LabelsService
+	Drafts   *DraftsService
+	Messages *MessagesService
+	History  *HistoryService
+	Settings *SettingsService
+	Threads  *ThreadsService
+}
+
+func (g *GmailService) GetLabelsService() Labeler {
+	return g.Labels
+}
+
+func (g *GmailService) GetMessagesService() Messenger {
+	return g.Messages
+}
+
+type DraftsService struct {
+	*gmail.UsersDraftsService
+}
+
+type HistoryService struct {
+	*gmail.UsersHistoryService
+}
+
+type SettingsService struct {
+	*gmail.UsersSettingsService
+}
+
+type ThreadsService struct {
+	*gmail.UsersThreadsService
+}

--- a/service.go
+++ b/service.go
@@ -4,30 +4,11 @@ import (
 	"context"
 
 	"github.com/go-kit/log"
+	"github.com/orlandorode97/mailx-google-service/pkg/google"
 	"github.com/orlandorode97/mailx-google-service/pkg/repos"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
-)
-
-// Type of service to return by GetGmailService.
-const (
-	// Returns gmailSvc.Users service.
-	UsersSvc = iota + 1
-	// Returns gmailSvc.Users.Labels service.
-	LabelSvc
-	// Returns gmailSvc.Users.Drafts service.
-	DraftsSvc
-	// Returns gmailSvc.Users.History service.
-	HistorySvc
-	// Returns gmailSvc.Users.Messages service.
-	MessagesSvc
-	// Returns gmailSvc.Users.Settings service.
-	SettingsSvc
-	// Returns gmailSvc.Users.Threads service.
-	ThreadsSvc
-	// Returns the whole gmailSvc.
-	GmailSvc
 )
 
 const (
@@ -43,19 +24,19 @@ const (
 
 type Creator interface {
 	// CreateGmailService returns a new gmail service instance.
-	CreateGmailService(*oauth2.Token) (*gmail.Service, error)
+	CreateGmailService(*oauth2.Token) (google.Service, error)
 	// RecreateGmailService returns a new gmail service when a service is not attached to a user
-	RecreateGmailService(context.Context, string) (*gmail.Service, error)
+	RecreateGmailService(context.Context, string) (google.Service, error)
 }
 
 type Getter interface {
-	// GetGmailService returns a interface of any gmail service such as Labels, Users, Drafts etc of the user based on typeSvc parameter.
-	GetGmailService(string, int) interface{}
+	// GetGmailService returns a pointer of gmail service.
+	GetGmailService(string) google.Service
 }
 
 type Setter interface {
 	// AddGmailServiceByID creates a new entry of a pointer gmail service by google user ID.
-	AddGmailServiceByID(string, *gmail.Service) *gmail.Service
+	AddGmailServiceByID(string, google.Service) google.Service
 }
 
 type Service interface {
@@ -70,7 +51,7 @@ type service struct {
 	config *oauth2.Config
 	repo   repos.TokenRepository
 	//Map that holds google user ID as a key and stores a pointer gmail service.
-	gmailSvcs map[string]*gmail.Service
+	gmailSvcs map[string]google.Service
 }
 
 func New(logger log.Logger, repo repos.TokenRepository, config *oauth2.Config) Service {
@@ -78,41 +59,24 @@ func New(logger log.Logger, repo repos.TokenRepository, config *oauth2.Config) S
 		logger:    logger,
 		config:    config,
 		repo:      repo,
-		gmailSvcs: make(map[string]*gmail.Service),
+		gmailSvcs: make(map[string]google.Service),
 	}
 }
 
-func (s *service) AddGmailServiceByID(ID string, gmailSvc *gmail.Service) *gmail.Service {
-	s.gmailSvcs[ID] = gmailSvc
+func (s *service) AddGmailServiceByID(userID string, gmailSvc google.Service) google.Service {
+	s.gmailSvcs[userID] = gmailSvc
 	return gmailSvc
 }
 
-func (s *service) GetGmailService(ID string, typeSvc int) interface{} {
-	gmailSvc, ok := s.gmailSvcs[ID]
-	if !ok {
-		return nil
-	}
-	switch typeSvc {
-	case UsersSvc:
-		return gmailSvc.Users
-	case LabelSvc:
-		return gmailSvc.Users.Labels
-	case DraftsSvc:
-		return gmailSvc.Users.Drafts
-	case HistorySvc:
-		return gmailSvc.Users.History
-	case MessagesSvc:
-		return gmailSvc.Users.Messages
-	case SettingsSvc:
-		return gmailSvc.Users.Settings
-	case ThreadsSvc:
-		return gmailSvc.Users.Threads
-	default:
+func (s *service) GetGmailService(userID string) google.Service {
+	if gmailSvc, ok := s.gmailSvcs[userID]; ok {
 		return gmailSvc
 	}
+
+	return nil
 }
 
-func (s *service) CreateGmailService(token *oauth2.Token) (*gmail.Service, error) {
+func (s *service) CreateGmailService(token *oauth2.Token) (google.Service, error) {
 	ctx := context.Background()
 	gmailSvc, err := gmail.NewService(ctx, option.WithTokenSource(s.config.TokenSource(ctx, token)))
 	if err != nil {
@@ -123,11 +87,14 @@ func (s *service) CreateGmailService(token *oauth2.Token) (*gmail.Service, error
 		)
 		return nil, err
 	}
-	return gmailSvc, nil
+
+	svc := s.hydrateServices(gmailSvc)
+
+	return svc, nil
 }
 
-func (s *service) RecreateGmailService(ctx context.Context, ID string) (*gmail.Service, error) {
-	token, err := s.repo.GetTokenByUserId(ctx, ID)
+func (s *service) RecreateGmailService(ctx context.Context, userID string) (google.Service, error) {
+	token, err := s.repo.GetTokenByUserId(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -138,9 +105,22 @@ func (s *service) RecreateGmailService(ctx context.Context, ID string) (*gmail.S
 		TokenType:    token.TokenType,
 		Expiry:       token.TokenExpiration,
 	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	return s.AddGmailServiceByID(ID, svc), nil
+	return s.AddGmailServiceByID(userID, svc), nil
+}
+
+func (s *service) hydrateServices(svc *gmail.Service) google.Service {
+	return &google.GmailService{
+		Users:    svc.Users,
+		Labels:   google.NewLabelsService(svc.Users.Labels),
+		Messages: google.NewMessagesService(svc.Users.Messages),
+		Drafts:   &google.DraftsService{},
+		History:  &google.HistoryService{},
+		Settings: &google.SettingsService{},
+		Threads:  &google.ThreadsService{},
+	}
 }

--- a/users/endpoint.go
+++ b/users/endpoint.go
@@ -1,0 +1,44 @@
+package users
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/orlandorode97/mailx-google-service/pkg/models"
+)
+
+type Endpoints struct {
+	GetUserByIdEndpoint endpoint.Endpoint
+}
+
+func MakeEndpoints(s Service) Endpoints {
+	return Endpoints{
+		GetUserByIdEndpoint: MakeGetUserByIdEndpoint(s),
+	}
+}
+
+func MakeGetUserByIdEndpoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req, _ := request.(getUserByIdRequest)
+		user, err := s.GetUserByID(req.UserID)
+		if err != nil {
+			return getUserByIdResponse{Err: err}, nil
+		}
+		return getUserByIdResponse{
+			User: user,
+		}, nil
+	}
+}
+
+type getUserByIdRequest struct {
+	UserID string
+}
+
+type getUserByIdResponse struct {
+	Err  error        `json:"error,omitempty"`
+	User *models.User `json:"user"`
+}
+
+func (g getUserByIdResponse) error() error {
+	return g.Err
+}

--- a/users/service.go
+++ b/users/service.go
@@ -1,0 +1,46 @@
+package users
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/orlandorode97/mailx-google-service"
+	"github.com/orlandorode97/mailx-google-service/pkg/models"
+	"github.com/orlandorode97/mailx-google-service/pkg/repos"
+)
+
+type Service interface {
+	GetUserByID(string) (*models.User, error)
+}
+
+type service struct {
+	logger   log.Logger
+	repo     repos.Repository
+	mailxSvc mailx.Service
+}
+
+func New(logger log.Logger, repo repos.Repository, mailx mailx.Service) Service {
+	return &service{
+		logger:   logger,
+		repo:     repo,
+		mailxSvc: mailx,
+	}
+}
+
+func (s *service) GetUserByID(ID string) (*models.User, error) {
+	user, err := s.repo.GetUserByID(context.Background(), ID)
+	if err != nil {
+		s.logger.Log(
+			"message", fmt.Sprintf("error getting user with ID %s ", ID),
+			"error", err.Error(),
+			"severity", "ERROR",
+		)
+		return nil, err
+	}
+	s.logger.Log(
+		"message", fmt.Sprintf("getting user with ID %s", ID),
+		"severity", "INFO",
+	)
+	return user, nil
+}

--- a/users/transport.go
+++ b/users/transport.go
@@ -1,0 +1,61 @@
+package users
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/orlandorode97/mailx-google-service/pkg/middlewares"
+	"github.com/orlandorode97/mailx-google-service/pkg/models"
+)
+
+func MakeHandler(usersService Service, logger log.Logger) http.Handler {
+	r := mux.NewRouter()
+	e := MakeEndpoints(usersService)
+
+	options := []kithttp.ServerOption{
+		kithttp.ServerErrorEncoder(models.ErrorEncoder),
+	}
+
+	r.Methods(http.MethodGet).
+		Path("/users/").
+		Handler(kithttp.NewServer(
+			e.GetUserByIdEndpoint,
+			decodeUsersRequest,
+			encodeUsersResponse,
+			options...,
+		))
+
+	return middlewares.Authentication(r)
+}
+
+func decodeUsersRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	if err, ok := r.Context().Value(middlewares.InvalidAuthKey).(error); ok && err != nil {
+		return nil, err
+	}
+
+	userID, ok := r.Context().Value(middlewares.UserIDKey).(string)
+	if !ok {
+		// return custom error
+		return nil, nil
+	}
+
+	return getUserByIdRequest{
+		UserID: userID,
+	}, nil
+}
+
+func encodeUsersResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	if e, ok := response.(errorer); ok && e.error() != nil {
+		return e.error()
+	}
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type errorer interface {
+	error() error
+}


### PR DESCRIPTION
### Summary
- Create a custom struct `GmailService` that embeds the `gmail.Service` for better abstraction.
- Creation of an abstraction of the `gmail.UsersLabelsService`.
- Creation of an abstraction of the `gmail.UsersMessagesService`.
- Creation of the `UsersService`.
- Creation of the `MessagesService`.
- Update unit tests for `AuthService`, `LabelsService`, and global service to use the `GmailService` struct.
- Handle for nil cases and interfaces with nil values. 
- Rename `userId` or `ID` to `userID`